### PR TITLE
Load OpenAI key from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+VITE_OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
+.env.local
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+Create a `.env` file based on `.env.example` and provide your OpenAI API key:
+
+```sh
+cp .env.example .env
+echo "VITE_OPENAI_API_KEY=your-openai-key" >> .env
+```
+
+The application reads `VITE_OPENAI_API_KEY` at runtime for connecting to OpenAI.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/ce75a6c3-2292-4fb9-842d-f505cfb6d646) and click on Share -> Publish.

--- a/src/services/aiServices.ts
+++ b/src/services/aiServices.ts
@@ -12,7 +12,7 @@ export const aiServices: AIService[] = [
     name: 'OpenAI GPT',
     type: 'openai',
     endpoint: 'https://api.openai.com/v1/chat/completions',
-    apiKey: 'demo-key', // Using demo key since the provided key is archived
+    apiKey: import.meta.env.VITE_OPENAI_API_KEY || '',
     model: 'gpt-4o-mini'
   },
   {
@@ -60,20 +60,11 @@ export async function callAIService(
     throw new Error(`AI service ${serviceType} not found`);
   }
 
-  // For demo purposes, return fallback responses for OpenAI since the key is archived
-  if (service.type === 'openai') {
-    console.log('Using fallback response for OpenAI service (archived key)');
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(getRandomFallbackResponse());
-      }, 1000); // Simulate API delay
-    });
-  }
-
-  // Handle non-OpenAI services
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    'api-key': service.apiKey
+    ...(service.type === 'openai'
+      ? { Authorization: `Bearer ${service.apiKey}` }
+      : { 'api-key': service.apiKey })
   };
 
   const requestBody = {


### PR DESCRIPTION
## Summary
- ignore `.env` files
- add `.env.example` with OpenAI key placeholder
- document env setup in README
- read OpenAI API key from `VITE_OPENAI_API_KEY`
- send correct authorization header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*