### PR TITLE
Add API server and settings/project pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration
+OPENAI_API_KEY=your-openai-key
+AZURE_API_KEY=your-azure-key

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ npm i
 npm run dev
 ```
 
+### Running the API server
+
+A lightweight Node server powers the demo API used by the UI. Start it in another terminal:
+
+```sh
+npm run server
+```
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/server/data.json
+++ b/server/data.json
@@ -1,0 +1,98 @@
+{
+  "projects": [
+    {
+      "id": "1",
+      "name": "E-commerce Store",
+      "status": "deployed",
+      "url": "store.example.com",
+      "lastUpdated": "2024-06-01T10:00:00Z",
+      "agents": ["Frontend", "Backend", "Database"]
+    },
+    {
+      "id": "2",
+      "name": "Portfolio Website",
+      "status": "building",
+      "url": "portfolio.staging.com",
+      "lastUpdated": "2024-06-01T11:00:00Z",
+      "agents": ["Design", "Frontend"]
+    },
+    {
+      "id": "3",
+      "name": "SaaS Dashboard",
+      "status": "planning",
+      "url": "Not deployed",
+      "lastUpdated": "2024-05-30T09:00:00Z",
+      "agents": ["Backend", "DevOps"]
+    }
+  ],
+  "sites": [
+    {
+      "id": "1",
+      "name": "E-commerce Store",
+      "domain": "store-abc123.pipeline.app",
+      "customDomain": "mystore.com",
+      "status": "active",
+      "lastDeployed": "2 hours ago",
+      "visitors": 2543,
+      "size": "12.4 MB"
+    },
+    {
+      "id": "2",
+      "name": "Portfolio Website",
+      "domain": "portfolio-def456.pipeline.app",
+      "status": "building",
+      "lastDeployed": "5 minutes ago",
+      "visitors": 892,
+      "size": "8.1 MB"
+    },
+    {
+      "id": "3",
+      "name": "SaaS Dashboard",
+      "domain": "saas-ghi789.pipeline.app",
+      "customDomain": "dashboard.myapp.io",
+      "status": "active",
+      "lastDeployed": "1 day ago",
+      "visitors": 5201,
+      "size": "24.7 MB"
+    },
+    {
+      "id": "4",
+      "name": "Blog Platform",
+      "domain": "blog-jkl012.pipeline.app",
+      "status": "inactive",
+      "lastDeployed": "3 days ago",
+      "visitors": 123,
+      "size": "5.2 MB"
+    }
+  ],
+  "tables": [
+    {
+      "id": "1",
+      "name": "users",
+      "records": 1250,
+      "lastModified": "2 hours ago",
+      "status": "active"
+    },
+    {
+      "id": "2",
+      "name": "projects",
+      "records": 89,
+      "lastModified": "1 day ago",
+      "status": "active"
+    },
+    {
+      "id": "3",
+      "name": "deployments",
+      "records": 342,
+      "lastModified": "3 hours ago",
+      "status": "active"
+    },
+    {
+      "id": "4",
+      "name": "analytics",
+      "records": 5670,
+      "lastModified": "5 minutes ago",
+      "status": "active"
+    }
+  ]
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,101 @@
+const http = require('http');
+const { randomUUID } = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const DATA_FILE = path.join(__dirname, 'data.json');
+let state = { projects: [], sites: [], tables: [] };
+try {
+  state = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+} catch (e) {
+  console.log('No data file, starting fresh');
+}
+
+function save() {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(state, null, 2));
+}
+
+function send(res, code, data) {
+  res.writeHead(code, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+function parseBody(req, cb) {
+  let body = '';
+  req.on('data', chunk => (body += chunk));
+  req.on('end', () => {
+    try {
+      cb(JSON.parse(body || '{}'));
+    } catch {
+      cb({});
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const { pathname } = url;
+
+  if (pathname === '/api/projects' && req.method === 'GET') {
+    return send(res, 200, state.projects);
+  }
+  if (pathname === '/api/projects' && req.method === 'POST') {
+    return parseBody(req, body => {
+      const project = {
+        id: randomUUID(),
+        name: body.name || 'New Project',
+        status: 'planning',
+        url: 'Not deployed',
+        lastUpdated: new Date().toISOString(),
+        agents: ['Frontend', 'Backend', 'Database']
+      };
+      state.projects.push(project);
+      save();
+      send(res, 200, project);
+    });
+  }
+  if (pathname.startsWith('/api/projects/') && req.method === 'GET') {
+    const id = pathname.split('/')[3];
+    const project = state.projects.find(p => p.id === id);
+    return project ? send(res, 200, project) : send(res, 404, { error: 'Not found' });
+  }
+  if (pathname.endsWith('/deploy') && req.method === 'POST') {
+    const id = pathname.split('/')[3];
+    const project = state.projects.find(p => p.id === id);
+    if (!project) return send(res, 404, { error: 'Not found' });
+    project.status = 'deployed';
+    project.url = `${project.name.toLowerCase().replace(/\s+/g, '-')}-${id.slice(0,6)}.pipeline.app`;
+    project.lastUpdated = new Date().toISOString();
+    const site = {
+      id: randomUUID(),
+      name: project.name,
+      domain: project.url,
+      status: 'active',
+      lastDeployed: 'just now',
+      visitors: 0,
+      size: '0 MB'
+    };
+    state.sites.push(site);
+    save();
+    return send(res, 200, project);
+  }
+  if (pathname === '/api/sites' && req.method === 'GET') {
+    return send(res, 200, state.sites);
+  }
+  if (pathname.startsWith('/api/sites/') && req.method === 'DELETE') {
+    const id = pathname.split('/')[3];
+    state.sites = state.sites.filter(s => s.id !== id);
+    save();
+    return send(res, 200, { success: true });
+  }
+  if (pathname === '/api/database/tables' && req.method === 'GET') {
+    return send(res, 200, state.tables);
+  }
+
+  send(res, 404, { error: 'Not found' });
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log('API server listening on', PORT);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import Dashboard from "./pages/Dashboard";
 import Chat from "./pages/Chat";
 import Sites from "./pages/Sites";
 import Database from "./pages/Database";
+import ProjectDetail from "./pages/ProjectDetail";
+import Settings from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -28,6 +30,8 @@ const App = () => (
               <Route path="/chat" element={<Chat />} />
               <Route path="/sites" element={<Sites />} />
               <Route path="/database" element={<Database />} />
+              <Route path="/project/:projectId" element={<ProjectDetail />} />
+              <Route path="/settings" element={<Settings />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,38 +1,19 @@
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Plus, Globe, Database, Settings, MessageSquare } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { getProjects } from "../services/api";
+import { Project } from "../types/app";
 
 const Dashboard = () => {
   const navigate = useNavigate();
-  const [projects] = useState([
-    {
-      id: 1,
-      name: "E-commerce Store",
-      status: "deployed",
-      url: "store.example.com",
-      lastUpdated: "2 hours ago",
-      agents: ["Frontend", "Backend", "Database"]
-    },
-    {
-      id: 2,
-      name: "Portfolio Website",
-      status: "building",
-      url: "portfolio.staging.com",
-      lastUpdated: "5 minutes ago",
-      agents: ["Design", "Frontend"]
-    },
-    {
-      id: 3,
-      name: "SaaS Dashboard",
-      status: "planning",
-      url: "Not deployed",
-      lastUpdated: "1 day ago",
-      agents: ["Backend", "DevOps"]
-    }
-  ]);
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    getProjects().then(setProjects);
+  }, []);
 
   const getStatusColor = (status: string) => {
     switch (status) {

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { getProject, deployProject } from "../services/api";
+import { Project } from "../types/app";
+
+const ProjectDetail = () => {
+  const { projectId } = useParams();
+  const navigate = useNavigate();
+  const [project, setProject] = useState<Project | null>(null);
+
+  useEffect(() => {
+    if (projectId) {
+      getProject(projectId).then(setProject).catch(() => navigate("/dashboard"));
+    }
+  }, [projectId, navigate]);
+
+  const deploy = async () => {
+    if (!projectId) return;
+    await deployProject(projectId);
+    const updated = await getProject(projectId);
+    setProject(updated);
+  };
+
+  if (!project) return null;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <Button variant="outline" onClick={() => navigate('/dashboard')}>Back</Button>
+        <Card className="border-0 shadow-lg bg-white/70 backdrop-blur">
+          <CardHeader>
+            <CardTitle className="text-lg">{project.name}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <p>Status: {project.status}</p>
+            <p>URL: {project.url}</p>
+            <div>
+              <p className="font-medium mb-1">Agents</p>
+              <div className="flex flex-wrap gap-1">
+                {project.agents.map(a => (
+                  <span key={a} className="px-2 py-1 bg-blue-100 rounded text-xs text-blue-800">{a}</span>
+                ))}
+              </div>
+            </div>
+            <Button onClick={deploy} className="bg-gradient-to-r from-blue-600 to-purple-600">Deploy</Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectDetail;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const Settings = () => {
+  const [openaiKey, setOpenaiKey] = useState("");
+  const [azureKey, setAzureKey] = useState("");
+
+  useEffect(() => {
+    setOpenaiKey(localStorage.getItem("openaiKey") || "");
+    setAzureKey(localStorage.getItem("azureKey") || "");
+  }, []);
+
+  const save = () => {
+    localStorage.setItem("openaiKey", openaiKey);
+    localStorage.setItem("azureKey", azureKey);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">
+      <div className="max-w-xl mx-auto space-y-6">
+        <Card className="border-0 shadow-lg bg-white/70 backdrop-blur">
+          <CardHeader>
+            <CardTitle className="text-lg">API Keys</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">OpenAI Key</label>
+              <Input value={openaiKey} onChange={e => setOpenaiKey(e.target.value)} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Azure Key</label>
+              <Input value={azureKey} onChange={e => setAzureKey(e.target.value)} />
+            </div>
+            <Button onClick={save} className="bg-gradient-to-r from-blue-600 to-purple-600">Save</Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;

--- a/src/pages/Sites.tsx
+++ b/src/pages/Sites.tsx
@@ -1,11 +1,13 @@
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Globe, Settings, Plus, ExternalLink, Copy, Trash2, Edit } from "lucide-react";
 import { toast } from "sonner";
+import { getSites, deleteSite } from "../services/api";
+import { Site } from "../types/app";
 
 interface Site {
   id: string;
@@ -19,46 +21,11 @@ interface Site {
 }
 
 const Sites = () => {
-  const [sites, setSites] = useState<Site[]>([
-    {
-      id: "1",
-      name: "E-commerce Store",
-      domain: "store-abc123.pipeline.app",
-      customDomain: "mystore.com",
-      status: "active",
-      lastDeployed: "2 hours ago",
-      visitors: 2543,
-      size: "12.4 MB"
-    },
-    {
-      id: "2",
-      name: "Portfolio Website",
-      domain: "portfolio-def456.pipeline.app",
-      status: "building",
-      lastDeployed: "5 minutes ago",
-      visitors: 892,
-      size: "8.1 MB"
-    },
-    {
-      id: "3",
-      name: "SaaS Dashboard",
-      domain: "saas-ghi789.pipeline.app",
-      customDomain: "dashboard.myapp.io",
-      status: "active",
-      lastDeployed: "1 day ago",
-      visitors: 5201,
-      size: "24.7 MB"
-    },
-    {
-      id: "4",
-      name: "Blog Platform",
-      domain: "blog-jkl012.pipeline.app",
-      status: "inactive",
-      lastDeployed: "3 days ago",
-      visitors: 123,
-      size: "5.2 MB"
-    }
-  ]);
+  const [sites, setSites] = useState<Site[]>([]);
+
+  useEffect(() => {
+    getSites().then(setSites);
+  }, []);
 
   const [showAddDomain, setShowAddDomain] = useState<string | null>(null);
   const [newDomain, setNewDomain] = useState("");
@@ -90,7 +57,8 @@ const Sites = () => {
     toast.success("Custom domain added successfully!");
   };
 
-  const deleteSite = (siteId: string) => {
+  const handleDeleteSite = async (siteId: string) => {
+    await deleteSite(siteId);
     setSites(sites.filter(site => site.id !== siteId));
     toast.success("Site deleted successfully!");
   };
@@ -227,10 +195,10 @@ const Sites = () => {
                     <Button variant="ghost" size="sm">
                       <Edit className="h-4 w-4" />
                     </Button>
-                    <Button 
-                      variant="ghost" 
+                    <Button
+                      variant="ghost"
                       size="sm"
-                      onClick={() => deleteSite(site.id)}
+                      onClick={() => handleDeleteSite(site.id)}
                       className="text-red-600 hover:text-red-700"
                     >
                       <Trash2 className="h-4 w-4" />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,25 @@
+export async function apiRequest(path: string, options: RequestInit = {}) {
+  const response = await fetch(`/api${path}`, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+    ...(options.body ? { body: JSON.stringify(options.body) } : {}),
+  } as RequestInit);
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || 'Request failed');
+  }
+
+  return response.json();
+}
+
+export const getProjects = () => apiRequest('/projects');
+export const createProject = (name: string) =>
+  apiRequest('/projects', { method: 'POST', body: { name } });
+export const getProject = (id: string) => apiRequest(`/projects/${id}`);
+export const deployProject = (id: string) =>
+  apiRequest(`/projects/${id}/deploy`, { method: 'POST' });
+
+export const getSites = () => apiRequest('/sites');
+export const deleteSite = (id: string) =>
+  apiRequest(`/sites/${id}`, { method: 'DELETE' });

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,0 +1,27 @@
+export interface Project {
+  id: string;
+  name: string;
+  status: string;
+  url: string;
+  lastUpdated: string;
+  agents: string[];
+}
+
+export interface Site {
+  id: string;
+  name: string;
+  domain: string;
+  customDomain?: string;
+  status: string;
+  lastDeployed: string;
+  visitors: number;
+  size: string;
+}
+
+export interface DatabaseTable {
+  id: string;
+  name: string;
+  records: number;
+  lastModified: string;
+  status: "active" | "inactive";
+}


### PR DESCRIPTION
## Summary
- implement simple Node API server with JSON storage
- fetch data from server in Dashboard and Sites pages
- add project detail and settings pages
- add REST API helper utilities and type definitions
- update routing and docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*