### PR TITLE
Add docs and support page

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Documentation & Support
+
+Detailed project documentation is located in the [docs](./docs/README.md) directory. If you need help or want to report an issue, see [docs/SUPPORT.md](./docs/SUPPORT.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,75 @@
+# idea-ai-webforge Documentation
+
+This project is a React application scaffolded with Vite. It showcases an AI-powered development pipeline with a minimal Node.js API server.
+
+## Contents
+- [Overview](#overview)
+- [Local Development](#local-development)
+- [API Server](#api-server)
+- [Project Structure](#project-structure)
+- [Environment Variables](#environment-variables)
+- [Testing & Linting](#testing--linting)
+- [Deployment](#deployment)
+- [Support](#support)
+
+## Overview
+
+The application provides a dashboard for deploying websites and web apps using a collection of AI agents. It includes a chat interface for issuing commands, site management pages and database utilities.
+
+## Local Development
+
+Install dependencies and start the application with hot reloading:
+
+```bash
+npm install
+npm run dev
+```
+
+The app runs on <http://localhost:5173> by default. For the mock API server, open another terminal and run:
+
+```bash
+npm run server
+```
+
+## API Server
+
+The API server under `server/` is a lightweight Node.js HTTP server that stores data to `server/data.json`. It exposes endpoints for projects, deployments, sites and database tables. The server listens on port `3001` unless `PORT` is specified.
+
+## Project Structure
+
+```
+src/        – React application source code
+server/     – Minimal Node.js API server
+public/     – Static assets served by Vite
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and set your OpenAI API key:
+
+```bash
+cp .env.example .env
+echo "VITE_OPENAI_API_KEY=YOUR_KEY" >> .env
+```
+
+## Testing & Linting
+
+Run ESLint to check code style:
+
+```bash
+npm run lint
+```
+
+A production build can be generated with:
+
+```bash
+npm run build
+```
+
+## Deployment
+
+Static files produced by the build can be served from any web server. Deployments are simulated via the API server. In a real environment you would replace the API with your deployment pipeline.
+
+## Support
+
+See [SUPPORT.md](./SUPPORT.md) for ways to get help or report issues.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,29 @@
+# Support Guide
+
+If you encounter issues or have questions about **idea-ai-webforge**, use the following channels to get help:
+
+## 1. Check the Documentation
+
+Start with the [project documentation](./README.md) for installation steps, usage instructions and project structure.
+
+## 2. Open an Issue
+
+For bug reports or feature requests, open a GitHub issue in this repository. Provide as much detail as possible including steps to reproduce and any relevant logs.
+
+## 3. Contact the Maintainers
+
+Email support is available at:
+
+```
+support@example.com
+```
+
+We aim to respond within 2 business days.
+
+## 4. Community Discussions
+
+Join the discussion board on GitHub to connect with other users and contributors.
+
+## Security Concerns
+
+If you discover a security vulnerability, please contact the maintainers directly rather than opening a public issue.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Sites from "./pages/Sites";
 import Database from "./pages/Database";
 import ProjectDetail from "./pages/ProjectDetail";
 import Settings from "./pages/Settings";
+import Support from "./pages/Support";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -32,6 +33,7 @@ const App = () => (
               <Route path="/database" element={<Database />} />
               <Route path="/project/:projectId" element={<ProjectDetail />} />
               <Route path="/settings" element={<Settings />} />
+              <Route path="/support" element={<Support />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -24,6 +24,7 @@ const Navigation = () => {
     { icon: Globe, label: "Sites", path: "/sites" },
     { icon: Database, label: "Database", path: "/database" },
     { icon: Settings, label: "Settings", path: "/settings" },
+    { icon: MessageSquare, label: "Support", path: "/support" },
   ];
 
   const isActive = (path: string) => location.pathname === path;

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -1,0 +1,36 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Mail, Github } from "lucide-react";
+
+const Support = () => (
+  <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">
+    <div className="max-w-xl mx-auto space-y-6">
+      <Card className="border-0 shadow-lg bg-white/70 backdrop-blur">
+        <CardHeader>
+          <CardTitle className="text-lg">Need Help?</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-slate-700">
+          <p>
+            Check the full documentation under <code>docs/</code> in the repository.
+            If you run into issues or have questions, we are happy to assist.
+          </p>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Mail className="h-4 w-4" />
+              <span>support@example.com</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Github className="h-4 w-4" />
+              <span>Open an issue on GitHub</span>
+            </div>
+          </div>
+          <p>
+            For security concerns please contact us privately before disclosing
+            information publicly.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  </div>
+);
+
+export default Support;


### PR DESCRIPTION
## Summary
- document project in `docs/README.md`
- add support guidelines in `docs/SUPPORT.md`
- link docs from root README
- add Support page with new route and menu link

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*